### PR TITLE
Remove temporary array allocation from rotation functions

### DIFF
--- a/rotateX.js
+++ b/rotateX.js
@@ -9,21 +9,20 @@ module.exports = rotateX;
  * @returns {vec3} out
  */
 function rotateX(out, a, b, c){
-    var p = [], r=[]
-    //Translate point to the origin
-    p[0] = a[0] - b[0]
-    p[1] = a[1] - b[1]
-    p[2] = a[2] - b[2]
+    var by = b[1]
+    var bz = b[2]
 
-    //perform rotation
-    r[0] = p[0]
-    r[1] = p[1]*Math.cos(c) - p[2]*Math.sin(c)
-    r[2] = p[1]*Math.sin(c) + p[2]*Math.cos(c)
+    // Translate point to the origin
+    var py = a[1] - by
+    var pz = a[2] - bz
 
-    //translate to correct position
-    out[0] = r[0] + b[0]
-    out[1] = r[1] + b[1]
-    out[2] = r[2] + b[2]
+    var sc = Math.sin(c)
+    var cc = Math.cos(c)
+
+    // perform rotation and translate to correct position
+    out[0] = a[0]
+    out[1] = by + py * cc - pz * sc
+    out[2] = bz + py * cc + pz * sc
 
     return out
 }

--- a/rotateY.js
+++ b/rotateY.js
@@ -9,21 +9,20 @@ module.exports = rotateY;
  * @returns {vec3} out
  */
 function rotateY(out, a, b, c){
-    var p = [], r=[]
-    //Translate point to the origin
-    p[0] = a[0] - b[0]
-    p[1] = a[1] - b[1]
-    p[2] = a[2] - b[2]
+    var bx = b[0]
+    var bz = b[2]
+
+    // translate point to the origin
+    var px = a[0] - bx
+    var pz = a[2] - bz
+    
+    var sc = Math.sin(c)
+    var cc = Math.cos(c)
   
-    //perform rotation
-    r[0] = p[2]*Math.sin(c) + p[0]*Math.cos(c)
-    r[1] = p[1]
-    r[2] = p[2]*Math.cos(c) - p[0]*Math.sin(c)
-  
-    //translate to correct position
-    out[0] = r[0] + b[0]
-    out[1] = r[1] + b[1]
-    out[2] = r[2] + b[2]
+    // perform rotation and translate to correct position
+    out[0] = bx + pz * sc + px * cc
+    out[1] = a[1]
+    out[2] = bz + pz * cc - px * sc
   
     return out
 }

--- a/rotateZ.js
+++ b/rotateZ.js
@@ -9,21 +9,20 @@ module.exports = rotateZ;
  * @returns {vec3} out
  */
 function rotateZ(out, a, b, c){
-    var p = [], r=[]
+    var bx = b[0]
+    var by = b[1]
+
     //Translate point to the origin
-    p[0] = a[0] - b[0]
-    p[1] = a[1] - b[1]
-    p[2] = a[2] - b[2]
+    var px = a[0] - bx
+    var py = a[1] - by
   
-    //perform rotation
-    r[0] = p[0]*Math.cos(c) - p[1]*Math.sin(c)
-    r[1] = p[0]*Math.sin(c) + p[1]*Math.cos(c)
-    r[2] = p[2]
-  
-    //translate to correct position
-    out[0] = r[0] + b[0]
-    out[1] = r[1] + b[1]
-    out[2] = r[2] + b[2]
+    var sc = Math.sin(c)
+    var cc = Math.cos(c)
+
+    // perform rotation and translate to correct position
+    out[0] = bx + px * cc - py * sc
+    out[1] = by + px * sc + py * cc
+    out[2] = a[2]
   
     return out
 }


### PR DESCRIPTION
This PR removes temporary array allocation from rotateX, rotateY, and rotateZ, and optimizes a thing or two like redundant sines and cosines.