### PR TITLE
Update package.json license field to use non-deprecated syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "version": "1.1.3",
   "description": "gl-matrix's vec3, split into smaller pieces",
   "main": "index.js",
-  "license": {
-    "type": "zlib",
-    "url": "http://github.com/stackgl/gl-vec3/blob/master/LICENSE.md"
-  },
+  "license": "zlib",
   "contributors": [
     "Brandon Jones <tojiro@gmail.com>",
     "Colin MacKenzie IV <sinisterchipmunk@gmail.com>"


### PR DESCRIPTION
The object format for the "license" field is deprecated. See <https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license> for reference.